### PR TITLE
Seems like nestoria version is 1.21 is deprecated

### DIFF
--- a/lib/nestoria/api.rb
+++ b/lib/nestoria/api.rb
@@ -18,7 +18,7 @@ module Nestoria
 
   class Api
 
-    API_VERSION = 1.21
+    API_VERSION = 1.22
 
     # Valid search parameters - See http://www.nestoria.co.uk/help/api-search-listings for key/value details
     LOCATION_KEYS = [ :place_name, :south_west, :north_east, :centre_point, :radius ]


### PR DESCRIPTION
Requests don't longer work with API version 1.21,
I am getting 500/Internal Server Error back.
Every example in the read me works with API version 1.22.
So I upgraded the Version string.

Signed-off-by: Simon Egli simon.egli@bbv.ch
