### PR TITLE
Adding lightweight Memcacher class

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,20 @@ There's also support for fetching the average house price information on an area
 
     Nestoria::Api.new(:uk).metadata :south_west => [50.965, -5.504], :north_east => [50.156, -5.136]
 
+Caching
+------
+
+If you want to cache your queries, so that you won't hit nestoria as often
+and at the same time speed up the process of getting respones, 
+you can enable caching by initializing the Api with additional parameters. 
+
+    Nestoria::Api.new(:uk, use_cache, max_age=5*60)
+    #e.g. Nestoria::Api.new(:uk, true)
+    #This will enable caching a response for 5 minutes 
+    # or
+    Nestoria::Api.new(:uk, true, 0.5)
+    #will enable caching for 0.5 seconds
+
 Contributing to Nestoria API Library
 ====================================
  

--- a/lib/nestoria/api.rb
+++ b/lib/nestoria/api.rb
@@ -32,7 +32,7 @@ module Nestoria
     def initialize(country, use_cache=false, max_age=MAX_AGE)
       @country = country
       #Check to see if we have a valid max_age, if not we will ignore caching
-      @use_cache = use_cache max_age.to_f <= 0 ? false : true
+      @use_cache = max_age.to_f <= 0 ? false : use_cache
       @max_age = max_age.to_f
     end
 

--- a/lib/nestoria/api.rb
+++ b/lib/nestoria/api.rb
@@ -31,7 +31,8 @@ module Nestoria
 
     def initialize(country, use_cache=false, max_age=MAX_AGE)
       @country = country
-      @use_cache = use_cache unless max_age.to_f <= 0
+      #Check to see if we have a valid max_age, if not we will ignore caching
+      @use_cache = use_cache max_age.to_f <= 0 ? false : true
       @max_age = max_age.to_f
     end
 

--- a/lib/nestoria/api.rb
+++ b/lib/nestoria/api.rb
@@ -26,9 +26,13 @@ module Nestoria
       :bedroom_min, :bedroom_max, :room_min, :room_max, :bathroom_min, :bathroom_max,
       :size_min, :size_max, :keywords, :keywords_exclude, :has_photo, :updated_min,
       :number_of_results, :page, :sort ] + LOCATION_KEYS
+    # How old our cached results can be
+    MAX_AGE = 5*60
 
-    def initialize(country)
+    def initialize(country, use_cache=false, max_age=MAX_AGE)
       @country = country
+      @use_cache = use_cache
+      @max_age = max_age
     end
 
     # Search nestoria property listings - See http://www.nestoria.co.uk/help/api-search-listings
@@ -76,6 +80,46 @@ module Nestoria
 
     private
 
+    #Lightweight URL cacher class, caches requests to speed up the app
+    #Source by https://developer.yahoo.com/ruby/ruby-cache.html
+    class MemCache
+        def initialize
+            # we initialize an empty hash
+            @cache = {}
+        end
+        def fetch(url, max_age=0)
+            # if the API URL exists as a key in cache, we just return it
+            # we also make sure the data is fresh
+            if @cache.has_key? url
+                return @cache[url][1] if Time.now-@cache[url][0]<max_age
+            end
+            puts "Cache miss, getting "+url
+            # if the URL does not exist in cache or the data is not fresh,
+            #  we fetch again and store in cache
+            @cache[url] = [Time.now, Net::HTTP.get_response(URI.parse(url)).body]
+            return @cache[url][1]
+        end
+        def invalidate(url=nil)
+            if(url)
+                @cache[url][0] = 0
+            else
+                @cache = {}
+            end
+        end
+    end
+
+    def fetch_url(url, max_age=@max_age)
+        if @use_cache then
+            @@fetcher ||= MemCache.new
+            res = @@fetcher.fetch(url, max_age)
+            data = JSON.parse(res)
+        else
+            res = Net::HTTP.get_response(URI.parse(url))
+            data = JSON.parse(res.body)
+        end
+        return data
+    end
+
     def base_url
       domains = {:au => "api.nestoria.com.au",
                  :br => "api.nestoria.com.br",
@@ -97,9 +141,7 @@ module Nestoria
     def request(action, params = {})
       url = "#{base_url}?version=#{API_VERSION}&action=#{action}&encoding=json&#{params.to_query}"
       puts url
-      res = Net::HTTP.get_response(URI.parse(url))
-      data = JSON.parse(res.body)
-
+      data = fetch_url(url)
       # Catch any errors returned from the API and raise an appropriate exception
       if action.to_s == "search"
         application_response_code = data["response"]["application_response_code"]

--- a/lib/nestoria/api.rb
+++ b/lib/nestoria/api.rb
@@ -82,7 +82,8 @@ module Nestoria
     private
 
     #Lightweight URL cacher class, caches requests to speed up the app
-    #Source by https://developer.yahoo.com/ruby/ruby-cache.html
+    #Basic Source by https://developer.yahoo.com/ruby/ruby-cache.html, 
+    #extended the class a bit
     class MemCache
         def initialize
             # we initialize an empty hash

--- a/lib/nestoria/api.rb
+++ b/lib/nestoria/api.rb
@@ -31,8 +31,8 @@ module Nestoria
 
     def initialize(country, use_cache=false, max_age=MAX_AGE)
       @country = country
-      @use_cache = use_cache
-      @max_age = max_age
+      @use_cache = use_cache unless max_age.to_f <= 0
+      @max_age = max_age.to_f
     end
 
     # Search nestoria property listings - See http://www.nestoria.co.uk/help/api-search-listings


### PR DESCRIPTION
Added a lightweight cache class for caching the responses.
So far the module always gets it's response directly from nestoria.
I added a caching class which is off by default (so this is a drop in update).
But with the right parameters it will perform caching.
So far the caching is be done with a simple hash, for bigger applications
a more sophisticated approach may be useful
(e.g. ActiveSupport::Cache::MemoryStore or FileStore). 

I needed this and thus extended the module for myself.
Not sure if you are interested in this, but decided to make a pull request to see if you're interested

Signed-off-by: Simon Egli deadolus@gmail.com
